### PR TITLE
Feature/apiSet: API 초기 설정, 노트북 목록 가져오기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
@@ -5450,6 +5451,29 @@
       "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14789,6 +14813,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://3.39.198.156:8080/api/',
+  withCredentials: true,
+});
+
+export default api;

--- a/src/api/notebook/getNotebookList.js
+++ b/src/api/notebook/getNotebookList.js
@@ -8,7 +8,21 @@ const getNotebookList = async ({ currentPage }) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('API 요청 중 오류 발생', error);
+    // 에러 유형에 따라 처리
+    if (error.response) {
+      // 서버가 응답했지만 오류 상태 코드가 반환됨
+      console.error('응답 오류:', error.response.data);
+      throw new Error('서버 오류 발생');
+    } else if (error.request) {
+      // 요청이 전송되었지만 응답을 받지 못함
+      console.error('네트워크 오류 또는 서버 응답 없음');
+      throw new Error('네트워크 오류 또는 서버 응답 없음');
+    } else {
+      // 요청 설정 중 발생한 오류
+      console.error('요청 설정 오류:', error.message);
+      throw new Error('요청 설정 오류');
+    }
   }
 };
 

--- a/src/api/notebook/getNotebookList.js
+++ b/src/api/notebook/getNotebookList.js
@@ -1,0 +1,15 @@
+import api from 'api/axios';
+
+const getNotebookList = async ({ currentPage }) => {
+  try {
+    const response = await api.get(
+      `notebooks/read/${currentPage}?filterBy=none&selected=&onlyAvailable=false`,
+    );
+
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+};
+
+export default getNotebookList;

--- a/src/components/common/Banner.js
+++ b/src/components/common/Banner.js
@@ -2,7 +2,9 @@ import React from 'react';
 import { ListBanner } from 'styles/common/List-styled';
 
 const Banner = ({ data, text }) => {
-  return <ListBanner backgroundImage={data}>{text}</ListBanner>;
+  return (
+    <ListBanner style={{ backgroundImage: `url(${data})` }}>{text}</ListBanner>
+  );
 };
 
 export default Banner;

--- a/src/components/common/Location.js
+++ b/src/components/common/Location.js
@@ -7,11 +7,12 @@ const Location = ({ locations }) => {
       HOME
       {locations.map((el, index) => {
         return index === locations.length - 1 ? (
-          <>
-            &gt; <span style={{ color: 'black', fontWeight: '500' }}>{el}</span>
-          </>
+          <span key={index}>
+            &gt;
+            <span style={{ color: 'black', fontWeight: '500' }}>{el}</span>
+          </span>
         ) : (
-          <>&gt; {el}</>
+          <span key={index}>&gt; {el}</span>
         );
       })}
     </Wrapper>

--- a/src/components/common/list/InfoCard.js
+++ b/src/components/common/list/InfoCard.js
@@ -16,7 +16,11 @@ const InfoCard = ({ el, index, columns }) => {
               textAlign: colIndex === 1 ? 'start' : 'center',
             }}
           >
-            {el[column.key]}
+            {el[column.key] === 'AVAILABLE'
+              ? '대여가능'
+              : el[column.key] === 'RESERVATION'
+                ? '대여불가'
+                : el[column.key]}
           </div>
         ),
       )}

--- a/src/components/common/list/List.js
+++ b/src/components/common/list/List.js
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Bottom,
   HeadLine,
@@ -11,21 +10,16 @@ import {
 import SearchBox from 'components/common/SearchBox';
 import InfoCard from 'components/common/list/InfoCard';
 
-const List = ({ itemText, columns, currentData, buttonText }) => {
-  const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 10;
-
-  const totalPages = Math.ceil(currentData.length / itemsPerPage);
-
-  const currentItem = currentData.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage,
-  );
-
-  const handlePageChange = (page) => {
-    setCurrentPage(page);
-  };
-
+const List = ({
+  itemText,
+  columns,
+  currentData,
+  buttonText,
+  currentPage,
+  setCurrentPage,
+  totalPages,
+  totalElements,
+}) => {
   return (
     <ListWrapper>
       <Top>
@@ -45,13 +39,12 @@ const List = ({ itemText, columns, currentData, buttonText }) => {
           </div>
         ))}
       </HeadLine>
-      {currentItem.map((el, index) => {
-        const displayIndex = (currentPage - 1) * itemsPerPage + index + 1;
+      {currentData.map((el, index) => {
         return (
           <InfoCard
             key={index}
             el={el}
-            index={displayIndex}
+            index={totalElements - 10 * currentPage - index}
             columns={columns}
           />
         );
@@ -63,8 +56,10 @@ const List = ({ itemText, columns, currentData, buttonText }) => {
           {Array.from({ length: totalPages }, (_, index) => (
             <PagingBtn
               key={index}
-              isCurrentPage={currentPage === index + 1}
-              onClick={() => handlePageChange(index + 1)}
+              isCurrentPage={currentPage === index}
+              onClick={() => {
+                setCurrentPage(index);
+              }}
             >
               {index + 1}
             </PagingBtn>

--- a/src/components/login/RegisterLayout.js
+++ b/src/components/login/RegisterLayout.js
@@ -7,10 +7,9 @@ import {
   RegisterWrapper,
   ErrorMessage,
   ErrorWrapper,
-  Count,
   RegisterInput,
   NumInput,
-  RegisterButton
+  RegisterButton,
 } from 'styles/login/RegisterLayout-styled';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -19,7 +18,6 @@ function Register() {
   const {
     register,
     handleSubmit,
-    watch,
     formState: { errors },
   } = useForm();
 
@@ -30,7 +28,7 @@ function Register() {
   const [input, setInput] = useState({
     NumText1: '',
     NumText2: '',
-    NumText3: ''
+    NumText3: '',
   });
 
   function onChangeInput(e) {
@@ -38,10 +36,12 @@ function Register() {
       ...input,
       [e.target.name]: e.target.value,
     });
-  };
+  }
 
   function numInputCheck() {
-    return input.NumText1 != '' && input.NumText2 != '' && input.NumText3 != '';
+    return (
+      input.NumText1 !== '' && input.NumText2 !== '' && input.NumText3 !== ''
+    );
   }
 
   return (
@@ -54,41 +54,45 @@ function Register() {
             <RegisterInput
               isError={!!errors.studentId}
               {...register('studentId', {
-                required: '학번을 입력해주세요'
+                required: '학번을 입력해주세요',
               })}
             />
           </FormItem>
-          {errors.studentId && <ErrorMessage>{errors.studentId.message}</ErrorMessage>}
-        </ ErrorWrapper>
+          {errors.studentId && (
+            <ErrorMessage>{errors.studentId.message}</ErrorMessage>
+          )}
+        </ErrorWrapper>
         <ErrorWrapper>
           <FormItem>
             <Text>이름</Text>
             <RegisterInput
               isError={!!errors.name}
               {...register('name', {
-                required: '이름을 입력해주세요'
+                required: '이름을 입력해주세요',
               })}
             />
           </FormItem>
           {errors.name && <ErrorMessage>{errors.name.message}</ErrorMessage>}
-        </ ErrorWrapper>
+        </ErrorWrapper>
         <ErrorWrapper>
           <FormItem>
             <Text>새 비밀번호</Text>
             <RegisterInput
               isError={!!errors.password}
               {...register('password', {
-                required: '새 비밀번호를 입력해주세요'
+                required: '새 비밀번호를 입력해주세요',
               })}
             />
           </FormItem>
-          {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
-        </ ErrorWrapper>
+          {errors.password && (
+            <ErrorMessage>{errors.password.message}</ErrorMessage>
+          )}
+        </ErrorWrapper>
         <ErrorWrapper>
           <FormItem
             isError={!!errors.num}
             {...register('num', {
-              required: !numInputCheck() ? '휴대폰 번호를 입력해주세요' : false
+              required: !numInputCheck() ? '휴대폰 번호를 입력해주세요' : false,
             })}
           >
             <Text>휴대폰 번호</Text>
@@ -98,8 +102,8 @@ function Register() {
               name="NumText1"
               isError={!!errors.num}
               style={{
-                left: "120px",
-                width: "33px"
+                left: '120px',
+                width: '33px',
               }}
             />
             <NumText>-</NumText>
@@ -117,28 +121,28 @@ function Register() {
               name="NumText3"
               isError={!!errors.num}
               maxLength={4}
-
             />
           </FormItem>
           {errors.num && <ErrorMessage>{errors.num.message}</ErrorMessage>}
-        </ ErrorWrapper>
+        </ErrorWrapper>
         <ErrorWrapper>
           <FormItem>
             <Text>이메일</Text>
             <RegisterInput
               isError={!!errors.email}
               {...register('email', {
-                required: '이메일을 입력해주세요'
+                required: '이메일을 입력해주세요',
               })}
             />
           </FormItem>
           {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
-        </ ErrorWrapper>
-        <RegisterButton onClick={handleSubmit(onSubmit)}>등록하기</RegisterButton>
+        </ErrorWrapper>
+        <RegisterButton onClick={handleSubmit(onSubmit)}>
+          등록하기
+        </RegisterButton>
       </Form>
     </RegisterWrapper>
   );
 }
-
 
 export default Register;

--- a/src/components/notebook/NotebookListLayout.js
+++ b/src/components/notebook/NotebookListLayout.js
@@ -1,73 +1,46 @@
+import getNotebookList from 'api/notebook/getNotebookList';
 import List from 'components/common/list/List';
+import { useEffect, useState } from 'react';
 
 function NotebookListLayout() {
   const columns = [
-    { label: '번호', width: '5%' },
-    { label: '모델명', width: '60%', key: 'model' },
-    { label: '운영체제', width: '25%', key: 'os' },
-    { label: '대여상태', width: '10%', key: 'rentalStatus' },
+    { label: '번호', width: '10%' },
+    { label: '모델명', width: '55%', key: 'model' },
+    { label: '운영체제', width: '20%', key: 'os' },
+    { label: '대여상태', width: '15%', key: 'rentalStatus' },
   ];
 
-  const nobtebookData = [
-    {
-      model: 'LG 13세대 울트라북 LG ULTRA 15U50R (32G/512G)',
-      os: 'Windows 11',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: '애플 맥북프로 14 M1 512GB 스페이스 그레이',
-      os: 'Mac OS',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: 'LG 13세대 울트라북 LG ULTRA 15U50R (32G/512G)',
-      os: 'Windows 11',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: '애플 맥북프로 14 M1 512GB 스페이스 그레이',
-      os: 'Mac OS',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: 'LG 13세대 울트라북 LG ULTRA 15U50R (32G/512G)',
-      os: 'Windows 11',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: 'LG 13세대 울트라북 LG ULTRA 15U50R (32G/512G)',
-      os: 'Windows 11',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: '애플 맥북프로 14 M1 512GB 스페이스 그레이',
-      os: 'Mac OS',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: '애플 맥북프로 14 M1 512GB 스페이스 그레이',
-      os: 'Mac OS',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: '애플 맥북프로 14 M1 512GB 스페이스 그레이',
-      os: 'Mac OS',
-      rentalStatus: '대여가능',
-    },
-    {
-      model: '애플 맥북프로 14 M1 512GB 스페이스 그레이',
-      os: 'Mac OS',
-      rentalStatus: '대여가능',
-    },
-  ];
+  const [notebookList, setNotebookList] = useState([]);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+
+  useEffect(() => {
+    const fetchNotebookList = async () => {
+      try {
+        const response = await getNotebookList({ currentPage });
+        setNotebookList(response.content);
+        setTotalPages(response.totalPages);
+        setTotalElements(response.totalElements);
+        console.log('response', response);
+      } catch (error) {
+        console.log('error', error);
+      }
+    };
+    fetchNotebookList();
+  }, [currentPage]);
 
   return (
     <>
       <List
         itemText="개의 노트북이 등록되어 있습니다."
         columns={columns}
-        currentData={nobtebookData}
+        currentData={notebookList}
         buttonText="신규 등록"
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        totalPages={totalPages}
+        totalElements={totalElements}
       />
     </>
   );

--- a/src/components/notebook/NotebookListLayout.js
+++ b/src/components/notebook/NotebookListLayout.js
@@ -15,22 +15,23 @@ function NotebookListLayout() {
   const [totalPages, setTotalPages] = useState(0);
   const [totalElements, setTotalElements] = useState(0);
 
+  const fetchNotebookList = async (page) => {
+    try {
+      const response = await getNotebookList({ currentPage: page });
+      setNotebookList(response.content);
+      setTotalPages(response.totalPages);
+      setTotalElements(response.totalElements);
+      console.log('response', response);
+    } catch (error) {
+      console.error(
+        '노트북 리스트를 불러오는 데 실패하였습니다:',
+        error.message,
+      );
+    }
+  };
+
   useEffect(() => {
-    const fetchNotebookList = async () => {
-      try {
-        const response = await getNotebookList({ currentPage });
-        setNotebookList(response.content);
-        setTotalPages(response.totalPages);
-        setTotalElements(response.totalElements);
-        console.log('response', response);
-      } catch (error) {
-        console.error(
-          '노트북 리스트를 불러오는 데 실패하였습니다:',
-          error.message,
-        );
-      }
-    };
-    fetchNotebookList();
+    fetchNotebookList(currentPage);
   }, [currentPage]);
 
   return (

--- a/src/components/notebook/NotebookListLayout.js
+++ b/src/components/notebook/NotebookListLayout.js
@@ -24,7 +24,10 @@ function NotebookListLayout() {
         setTotalElements(response.totalElements);
         console.log('response', response);
       } catch (error) {
-        console.log('error', error);
+        console.error(
+          '노트북 리스트를 불러오는 데 실패하였습니다:',
+          error.message,
+        );
       }
     };
     fetchNotebookList();

--- a/src/styles/common/List-styled.js
+++ b/src/styles/common/List-styled.js
@@ -83,7 +83,9 @@ export const Bottom = styled.div`
   margin-top: 15px;
 `;
 
-export const PagingBtn = styled(Button)`
+export const PagingBtn = styled(Button).attrs((props) => ({
+  isCurrentPage: undefined, // DOM으로 전달되지 않도록 필터링
+}))`
   display: flex;
   justify-content: center;
   padding: 8px 16px;


### PR DESCRIPTION
## 개요
- API 초기 설정
- 노트북 목록 가져오기 API 연결
- 경고 발생 코드 리팩토링

## 구현 내용
- `axios.js` 파일에 axios 객체를 설정하여 baseURL을 지정해서 보다 쉽게 API 연결이 가능하도록 설정했습니다.
```jsx
const api = axios.create({
  baseURL: 'http://3.39.198.156:8080/api/',
  withCredentials: true,
});
```

- API 사용하실 떄 아래 코드 참고하셔서 사용하시면 됩니다!
```jsx
import api from 'api/axios';

const getNotebookList = async ({ currentPage }) => {
  try {
    const response = await api.get(
      `notebooks/read/${currentPage}?filterBy=none&selected=&onlyAvailable=false`,
    );

    return response.data;
  } catch (error) {
    console.error('API 요청 중 오류 발생', error);
    // 에러 유형에 따라 처리
    if (error.response) {
      // 서버가 응답했지만 오류 상태 코드가 반환됨
      console.error('응답 오류:', error.response.data);
      throw new Error('서버 오류 발생');
    } else if (error.request) {
      // 요청이 전송되었지만 응답을 받지 못함
      console.error('네트워크 오류 또는 서버 응답 없음');
      throw new Error('네트워크 오류 또는 서버 응답 없음');
    } else {
      // 요청 설정 중 발생한 오류
      console.error('요청 설정 오류:', error.message);
      throw new Error('요청 설정 오류');
    }
  }
};
```
- 위와 같이 에러 로깅을 자세하게 하면 아래처럼 에러의 가독성이 좋아집니다.
![image](https://github.com/user-attachments/assets/2e2494c3-1987-4269-ba4d-f9187c81a56c)

- 기존의 페이지 컨트롤러는 프론트 쪽에서 전체 데이터를 받은 후 페이지네이션을 하는 방식이었지만, 백엔드에서 페이지네이션을 해서 보내주는 방식으로 구현되어 방식을 변경했습니다.
- 경고 메시지가 뜨는 코드들은 전부 리팩토링해서 경고가 뜨지 않도록 수정했습니다.

## 기타
- 다른 페이지에서도 공통적인 부분들이 많아서 공통 컴포넌트로 구현하는 방식도 생각해보았지만, 괜히 더 복잡해질 것 같아서 일단 따로 구현해뒀습니다. 좋은 방식이 있으시다면 말씀해주세요!
- `axios` 라이브러리를 추가로 설치했습니다. 꼭 `npm i` 후에 개발하시기 바랍니다.