### PR TITLE
feature/adminDesign: 대여 요청 조회 및 승인 api 연결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ import NoticeReg from 'pages/notice/NoticeReg';
 import { useAuth } from 'api/context/AuthProvider';
 import NotebookModify from 'pages/notebook/NotebookModify';
 import { LoadingBar } from './components/common/LoadingBar';
-import AdminPage from 'pages/AdminPage';
+import RentalRequestList from 'pages/admin/RentalRequestList';
 
 const ProtectedRoute = ({ children, requiredRole }) => {
   const { user, isLoading } = useAuth();
@@ -169,12 +169,12 @@ function App() {
                 </ProtectedRoute>
               }
             />
-            {/* 관리자페이지 */}
+            {/* 관리자페이지의 메인은 대여 요청 조회*/}
             <Route
               path="adminpage"
               element={
                 <ProtectedRoute>
-                  <AdminPage />
+                  <RentalRequestList />
                 </ProtectedRoute>
               }
             />

--- a/src/api/admin/getRentalRequest.js
+++ b/src/api/admin/getRentalRequest.js
@@ -1,0 +1,25 @@
+import api from 'api/axios';
+
+const getRentalRequest = async ({ page = 0 }) => {
+  try {
+    const response = await api.get('/admin/request/rental', {
+      params: { page },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('대여 요청 리스트 API 호출 실패:', error);
+
+    if (error.response) {
+      console.error('응답 오류:', error.response.data);
+      throw new Error('서버 오류 발생');
+    } else if (error.request) {
+      console.error('네트워크 오류 또는 서버 응답 없음');
+      throw new Error('네트워크 오류 또는 서버 응답 없음');
+    } else {
+      console.error('요청 설정 오류:', error.message);
+      throw new Error('요청 설정 오류');
+    }
+  }
+};
+
+export default getRentalRequest;

--- a/src/api/admin/postRentalRequest.js
+++ b/src/api/admin/postRentalRequest.js
@@ -1,0 +1,50 @@
+import api from 'api/axios';
+
+const postRentalRequest = async (data, user) => {
+  if (!user) {
+    throw new Error('로그인이 필요합니다.');
+  }
+  if (user.role !== 'ADMIN') {
+    throw new Error('해당 요청에 대한 권한이 없습니다.');
+  }
+
+  try {
+    const response = await api.post(`admin/approve/{reservationId}`, data, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('전체 에러 객체:', error);
+
+    if (error.response) {
+      const errorCode = error.response.data?.code;
+      const errorMessage = error.response.data?.message;
+
+      console.error('응답 상태 코드:', error.response.status);
+      console.error('응답 에러 코드:', errorCode);
+      console.error('응답 에러 메시지:', errorMessage);
+
+      switch (errorCode) {
+        case 'AE1':
+          throw new Error('해당 요청에 대한 권한이 없습니다.');
+        case 'NE2':
+          throw new Error('잘못된 입력입니다. 필수 값을 확인해주세요.');
+        default:
+          throw new Error(
+            `예상치 못한 오류 발생: ${errorMessage || '오류 메시지가 없습니다.'}`,
+          );
+      }
+    } else if (error.request) {
+      console.error('요청 객체:', error.request);
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      console.error('요청 설정 오류:', error.message);
+      throw new Error('요청 설정 중 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default postRentalRequest;

--- a/src/components/common/admin/AdminPageLayout.js
+++ b/src/components/common/admin/AdminPageLayout.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const AdminPageLayout = () => {
+  return (
+    <>
+      <List
+        itemText="개의 노트북이 등록되어 있습니다."
+        columns={columns}
+        currentData={notebookList}
+        buttonText="신규 등록"
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        totalPages={totalPages}
+        totalElements={totalElements}
+      />
+    </>
+  );
+};
+
+export default AdminPageLayout;

--- a/src/components/common/admin/AdminPageLayout.js
+++ b/src/components/common/admin/AdminPageLayout.js
@@ -1,12 +1,52 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import List from 'components/common/list/List';
+import { LoadingBar } from 'components/common/LoadingBar';
+import getRentalRequest from 'api/admin/getRentalRequest';
 
-const AdminPageLayout = () => {
+function AdminRentalRequestLayout() {
+  const columns = [
+    { label: '학번', width: '13%', key: 'studentId' },
+    { label: '대여 중인 노트북', width: '23%', key: 'notebookId' },
+    { label: '연락처', width: '18%', key: 'contact' },
+    { label: '대여시작일자', width: '15%', key: 'rentalStartDate' },
+    { label: '반납예정일자', width: '15%', key: 'returnDueDate' },
+    // TODO: 클릭 시 대여 요청 승인 되는 버튼 구현 예정
+    { label: '버튼', width: '15%', key: 'returnDueDate' },
+  ];
+
+  const [rentalRequestList, setRentalRequestList] = useState([]);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const fetchRentalRequestList = async (page) => {
+    setLoading(true);
+    try {
+      const response = await getRentalRequest({ page });
+
+      setRentalRequestList(response.content || []);
+      setTotalPages(response.totalPages || 0);
+      setTotalElements(response.totalElements || 0);
+    } catch (error) {
+      console.error('대여 요청 리스트를 불러오는 데 실패하였습니다:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRentalRequestList(currentPage);
+  }, [currentPage]);
+
+  if (loading) return <LoadingBar />;
+
   return (
     <>
       <List
-        itemText="개의 노트북이 등록되어 있습니다."
+        itemText="개의 대여 요청이 있습니다."
         columns={columns}
-        currentData={notebookList}
+        currentData={rentalRequestList}
         buttonText="신규 등록"
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}
@@ -15,6 +55,6 @@ const AdminPageLayout = () => {
       />
     </>
   );
-};
+}
 
-export default AdminPageLayout;
+export default AdminRentalRequestLayout;

--- a/src/components/common/admin/AdminPageLayout.js
+++ b/src/components/common/admin/AdminPageLayout.js
@@ -2,16 +2,16 @@ import React, { useState, useEffect } from 'react';
 import List from 'components/common/list/List';
 import { LoadingBar } from 'components/common/LoadingBar';
 import getRentalRequest from 'api/admin/getRentalRequest';
+import postRentalRequest from 'api/admin/postRentalRequest';
 
-function AdminRentalRequestLayout() {
+function AdminRentalRequestLayout({ user }) {
   const columns = [
     { label: '학번', width: '13%', key: 'studentId' },
     { label: '대여 중인 노트북', width: '23%', key: 'notebookId' },
     { label: '연락처', width: '18%', key: 'contact' },
     { label: '대여시작일자', width: '15%', key: 'rentalStartDate' },
     { label: '반납예정일자', width: '15%', key: 'returnDueDate' },
-    // TODO: 클릭 시 대여 요청 승인 되는 버튼 구현 예정
-    { label: '버튼', width: '15%', key: 'returnDueDate' },
+    { label: '승인 버튼', width: '15%', key: 'button' }, // 버튼 렌더링을 위한 key
   ];
 
   const [rentalRequestList, setRentalRequestList] = useState([]);
@@ -35,6 +35,16 @@ function AdminRentalRequestLayout() {
     }
   };
 
+  const handleApproval = async (reservationId) => {
+    try {
+      const response = await postRentalRequest({ reservationId }, user);
+      alert(`대여 요청이 승인되었습니다: ${response.message}`);
+      fetchRentalRequestList(currentPage);
+    } catch (error) {
+      alert(`대여 요청 승인 실패: ${error.message}`);
+    }
+  };
+
   useEffect(() => {
     fetchRentalRequestList(currentPage);
   }, [currentPage]);
@@ -52,6 +62,21 @@ function AdminRentalRequestLayout() {
         setCurrentPage={setCurrentPage}
         totalPages={totalPages}
         totalElements={totalElements}
+        renderButton={(rowData) => (
+          <button
+            onClick={() => handleApproval(rowData.reservationId)}
+            style={{
+              padding: '5px 10px',
+              backgroundColor: 'var(--main-color)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+            }}
+          >
+            승인
+          </button>
+        )}
       />
     </>
   );

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { Wrapper, Content } from 'styles/common/List-styled';
 import myPageBanner from 'assets/mypage/myPageBanner.png';
 import Title from 'components/common/Title';
-import MyPageLayout from 'components/mypage/MyPageLayout';
+import AdminPageLayout from 'components/common/admin/AdminPageLayout';
 
 const MyPage = () => {
   return (
@@ -14,7 +14,7 @@ const MyPage = () => {
           locationText={['마이 페이지']}
           titleText={'반갑습니다, 홍길동님!'}
         />
-        <MyPageLayout />
+        <AdminPageLayout />
       </Content>
     </Wrapper>
   );

--- a/src/pages/admin/RentalRequestList.js
+++ b/src/pages/admin/RentalRequestList.js
@@ -5,8 +5,9 @@ import myPageBanner from 'assets/mypage/myPageBanner.png';
 import Title from 'components/common/Title';
 import SideBar from 'components/common/SideBar';
 import { Container, Wrapper, Content } from 'styles/AdminPage-styled';
+import List from 'components/common/list/List';
 
-const AdminPage = () => {
+const RentalRequestList = () => {
   return (
     <Wrapper>
       <Banner data={myPageBanner} text="관리자 페이지" />
@@ -17,10 +18,11 @@ const AdminPage = () => {
             locationText={['관리자 페이지']}
             titleText={'대여 요청 조회'}
           />
+          <List />
         </Content>
       </Container>
     </Wrapper>
   );
 };
 
-export default AdminPage;
+export default RentalRequestList;

--- a/src/pages/admin/RentalRequestList.js
+++ b/src/pages/admin/RentalRequestList.js
@@ -5,7 +5,7 @@ import myPageBanner from 'assets/mypage/myPageBanner.png';
 import Title from 'components/common/Title';
 import SideBar from 'components/common/SideBar';
 import { Container, Wrapper, Content } from 'styles/AdminPage-styled';
-import List from 'components/common/list/List';
+import AdminPageLayout from 'components/common/admin/AdminPageLayout';
 
 const RentalRequestList = () => {
   return (
@@ -18,7 +18,7 @@ const RentalRequestList = () => {
             locationText={['관리자 페이지']}
             titleText={'대여 요청 조회'}
           />
-          <List />
+          <AdminPageLayout />
         </Content>
       </Container>
     </Wrapper>

--- a/src/styles/SideBar-styled.js
+++ b/src/styles/SideBar-styled.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
-export const SidebarContainer = styled.div`
+export const SidebarContainer = styled.div.attrs(() => ({
+  isOpen: undefined,
+}))`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -15,21 +17,23 @@ export const SidebarContainer = styled.div`
   height: 100vh;
 `;
 
-export const SideButton = styled.button`
+export const SideButton = styled.button.attrs(() => ({
+  isOpen: undefined,
+}))`
   background: none;
   border: none;
-  cursor: pointer;
-  margin: 0; 
+  cursor: pointer;
+  margin: 0;
   position: absolute;
-  top: 20px; 
-  left: ${({ isOpen }) => (isOpen ? '220px' : '10px')}; 
+  top: 20px;
+  left: ${({ isOpen }) => (isOpen ? '220px' : '10px')};
   transform: translateX(-10%);
   z-index: 10;
 
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 40px; 
+  width: 40px;
   height: 40px;
 `;
 


### PR DESCRIPTION
## 개요

- 노트북 대여 요청 조회 api 연결 
- 노트북 대여 요청 승인 api 연결 

## 구현 내용
- [관리자페이지 사이드바 PR](https://github.com/YU-NotebookService/NS-web/pull/34) 관련 파일 이동 (82934749c89bee307974d847cd768ea01ec64c15)
- 관리자페이지에서 사용자로부터 받은 대여 요청을 **조회**하는 api 연결 (a382cc256cde247f9e8e14c953beaa45ae19f413)
-  대여 요청을 **승인**할 수 있는 api 연결(a8437561df5c7e48ba99f529f75feeca0670125e)

## 기타

- 대여 요청 페이지를 관리자페이지의 `main`으로 염두에 두고 구현하였음
- 추후 관리자 아이디로 로그인 시에만 접근이 가능하도록 구현 할 예정(`alert`)
- 대여 요청 api 연결 후 **승인버튼** ui 구현 예정