### PR TITLE
Feature/userExtendApi: 사용자 연장 신청 api 연결

### DIFF
--- a/src/api/notebook/postExtendNotebook.js
+++ b/src/api/notebook/postExtendNotebook.js
@@ -1,0 +1,46 @@
+import api from 'api/axios';
+
+const postExtendNotebook = async (data, notebookId) => {
+  try {
+    const response = await api.post(`extends/create/${notebookId}`, data, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return response.data; // 성공 시 응답 데이터 반환
+  } catch (error) {
+    console.error('전체 에러 객체:', error);
+
+    if (error.response) {
+      const { status, data } = error.response;
+
+      console.error('에러 발생:', {
+        상태코드: status,
+        에러코드: data?.code || '없음',
+        메시지: data?.message || '없음',
+      });
+
+      // 에러 코드별 메시지 처리
+      const errorMessage =
+        {
+          AE1: '권한이 없습니다. 관리자에게 문의하세요.',
+          NE1: '존재하지 않는 노트북 ID입니다. 다시 확인해주세요.',
+          UE6: '존재하지 않는 사용자입니다.',
+          RE3: '대여 중인 노트북이 없습니다.',
+          RE4: '이 노트북은 현재 사용자의 대여 중 항목이 아닙니다.',
+        }[data?.code] ||
+        `예상치 못한 오류 발생: ${data?.message || '오류 메시지가 없습니다.'}`;
+
+      throw new Error(errorMessage);
+    } else if (error.request) {
+      console.error('요청 객체:', error.request);
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      console.error('요청 설정 오류:', error.message);
+      throw new Error('요청 설정 중 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default postExtendNotebook;

--- a/src/components/mypage/NotebookRentalInfo.js
+++ b/src/components/mypage/NotebookRentalInfo.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   ExtendBtn,
   ExtendBtnWrapper,
@@ -9,24 +9,73 @@ import {
   InfoTitle,
   MyPageNotebookInfo,
 } from 'styles/MyPage-styled';
+import postExtendNotebook from 'api/notebook/postExtendNotebook';
 
-const NotebookRentalInfo = ({ notebookName, rentalDate }) => {
+const NotebookRentalInfo = ({
+  notebookId,
+  notebookName = '알 수 없음',
+  rentalDate = '알 수 없음',
+}) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hasExtended, setHasExtended] = useState(false);
+
+  const handleExtendRequest = async () => {
+    if (!notebookId) {
+      alert('노트북 ID가 유효하지 않습니다.');
+      return;
+    }
+
+    if (isSubmitting || hasExtended) return; // 중복 클릭 방지
+
+    setIsSubmitting(true);
+
+    try {
+      const requestData = { requestDate: new Date().toISOString() };
+      console.log('API 호출 준비:', requestData, notebookId);
+
+      const response = await postExtendNotebook(requestData, notebookId);
+      console.log('연장 신청 성공:', response);
+      alert('연장 신청이 성공적으로 완료되었습니다.');
+      setHasExtended(true);
+    } catch (error) {
+      const errorMessage =
+        error.response?.data?.message ||
+        '연장 신청 중 오류가 발생했습니다. 다시 시도해주세요.';
+      console.error('연장 신청 실패:', error);
+      alert(`오류: ${errorMessage}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   const RentalInfo = [
-    { label: '모델명', text: notebookName },
-    { label: '대여 기간', text: rentalDate },
+    { id: 'model', label: '모델명', text: notebookName },
+    { id: 'rentalDate', label: '대여 기간', text: rentalDate },
   ];
+
+  const renderButtonLabel = () => {
+    if (isSubmitting) return '신청 중...';
+    if (hasExtended) return '신청 완료';
+    return '연장 신청';
+  };
+
   return (
     <MyPageNotebookInfo>
       <InfoTitle>대여 중인 노트북 정보</InfoTitle>
       <InfoContent>
-        {RentalInfo.map((el, index) => (
-          <InfoLine>
-            <InfoLabel>{el.label}</InfoLabel>
-            <InfoText>{el.text}</InfoText>
+        {RentalInfo.map(({ id, label, text }) => (
+          <InfoLine key={id}>
+            <InfoLabel>{label}</InfoLabel>
+            <InfoText>{text}</InfoText>
           </InfoLine>
         ))}
         <ExtendBtnWrapper>
-          <ExtendBtn>연장 신청</ExtendBtn>
+          <ExtendBtn
+            onClick={handleExtendRequest}
+            disabled={isSubmitting || hasExtended}
+          >
+            {renderButtonLabel()}
+          </ExtendBtn>
         </ExtendBtnWrapper>
       </InfoContent>
     </MyPageNotebookInfo>

--- a/src/components/mypage/NotebookRentalInfo.js
+++ b/src/components/mypage/NotebookRentalInfo.js
@@ -11,11 +11,7 @@ import {
 } from 'styles/MyPage-styled';
 import postExtendNotebook from 'api/notebook/postExtendNotebook';
 
-const NotebookRentalInfo = ({
-  notebookId,
-  notebookName = '알 수 없음',
-  rentalDate = '알 수 없음',
-}) => {
+const NotebookRentalInfo = ({ myRentalInfo }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasExtended, setHasExtended] = useState(false);
 
@@ -48,16 +44,12 @@ const NotebookRentalInfo = ({
     }
   };
 
-
-
-
   const renderButtonLabel = () => {
     if (isSubmitting) return '신청 중...';
     if (hasExtended) return '신청 완료';
     return '연장 신청';
   };
 
-const NotebookRentalInfo = ({ myRentalInfo }) => {
   const rentalInfo =
     myRentalInfo && myRentalInfo.length > 0
       ? [
@@ -68,7 +60,6 @@ const NotebookRentalInfo = ({ myRentalInfo }) => {
           },
         ]
       : null;
-
 
   return (
     <MyPageNotebookInfo>
@@ -88,14 +79,13 @@ const NotebookRentalInfo = ({ myRentalInfo }) => {
                 onClick={handleExtendRequest}
                 disabled={isSubmitting || hasExtended}
               >
-              {renderButtonLabel()}
+                {renderButtonLabel()}
               </ExtendBtn>
             </ExtendBtnWrapper>
           </>
         ) : (
           <>대여중인 노트북이 없습니다.</>
         )}
-
       </InfoContent>
     </MyPageNotebookInfo>
   );


### PR DESCRIPTION
## 개요

- 사용자 연장 신청 api 연결

## 구현 내용

- 노트북 연장 신청하는 api 호출(9b8e41ac6253503550997559d57912e40e10e657)
- **연장하기** 버튼 클릭 시 사용자 대여 신청 api 호출(e354486596906e3314ffb80b2713b43b685fd1c8)
- 성공적으로 연장 완료 시 `연장 신청이 성공적으로 완료되었습니다` 알림

## 기타

- 현재 사용자 마이페이지에 대여 현황 조회하는 부분 이슈 발생으로 화면 구현은 되고 있지 않음